### PR TITLE
Rename the VSCode extension

### DIFF
--- a/k-vscode/CHANGELOG.md
+++ b/k-vscode/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "K framework" extension will be documented in this fi
 
 ## [Unreleased]
 
-- Goto definition
+- Full Goto definition
 
 - Workspace navigation
 
@@ -12,6 +12,15 @@ All notable changes to the "K framework" extension will be documented in this fi
 
 - Automatic support for klsp inside Markdown files. Right now you have
   to manually select the Language Mode in the bottom right.
+
+## [0.1.2] - 2023-01-30
+
+- Rename extension name from RuntimeVerification.k-syntax to RuntimeVerification.k-vscode
+  to better encapsulate the scope of the project.
+
+- Require K v5.5.73 or higher. The extension is still going to work but the klsp adds more functionality, like:
+  - Goto definition for imported modules and required files
+  - Contextual completion for keywords, imported modules and syntax with tabstops.
 
 ## [0.1.1] - 2023-01-23
 

--- a/k-vscode/package-lock.json
+++ b/k-vscode/package-lock.json
@@ -1,6 +1,6 @@
 {
-    "name": "k-syntax",
-    "version": "0.1.1",
+    "name": "k-vscode",
+    "version": "0.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/k-vscode/package.json
+++ b/k-vscode/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "k-syntax",
+    "name": "k-vscode",
     "displayName": "K framework",
-    "description": "Syntax highlighting for the K language",
-    "version": "0.1.1",
+    "description": "Syntax highlighting and LSP support for the K framework",
+    "version": "0.1.2",
     "icon": "k-logo.png",
     "author": {
         "name": "Runtime Verification",


### PR DESCRIPTION
to better encapsulate the scope of the project