### PR TITLE
Make .md files open as K by default

### DIFF
--- a/k-vscode/CHANGELOG.md
+++ b/k-vscode/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to the "K framework" extension will be documented in this fi
 
 - Full error reporting inside the editor
 
-- Automatic support for klsp inside Markdown files. Right now you have
-  to manually select the Language Mode in the bottom right.
+## [0.2.4] - 2023-6-20
+
+- Automatically associate Markdown files with the K extension. To get hte old
+  behavior you can manually select the extension mode in the bottom right, or
+  disable this extension.
 
 ## [0.2.3] - 2023-03-08
 

--- a/k-vscode/CHANGELOG.md
+++ b/k-vscode/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the "K framework" extension will be documented in this fi
 
 ## [0.2.4] - 2023-6-20
 
-- Automatically associate Markdown files with the K extension. To get hte old
+- Automatically associate Markdown files with the K extension. To get the old
   behavior you can manually select the extension mode in the bottom right, or
   disable this extension.
 

--- a/k-vscode/README.md
+++ b/k-vscode/README.md
@@ -33,10 +33,9 @@ here: https://github.com/runtimeverification/k
   the location information gets out of sync, you may need to clean and
   rekompile your definition.
 
-- To enable `klsp` in Markdown you have to manually select the
-  Language Mode in the bottom right. To make this the default behavior
-  you can modify the Workspace Settings by adding
-  `"files.associations": { "*.md": "kframework" }` in your `package.json`.
+- Warning: this extension overrides the default extension for Markdown files.
+  To get the old behavior back you will have to manually select Markdown in the bottom right
+  or disable this extension.
 
 ### Contribute
 

--- a/k-vscode/package-lock.json
+++ b/k-vscode/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "k-vscode",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/k-vscode/package.json
+++ b/k-vscode/package.json
@@ -2,7 +2,7 @@
     "name": "k-vscode",
     "displayName": "K Framework",
     "description": "Syntax highlighting and LSP support for the K Framework",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "icon": "k-logo.png",
     "author": {
         "name": "Runtime Verification",
@@ -35,6 +35,7 @@
                 ],
                 "extensions": [
                     ".k"
+                    ,".md"
                 ],
                 "configuration": "./language-configuration.json"
             },


### PR DESCRIPTION
This should avoid some confusion.
I had multiple people ask why the extension doesn't work in Markdown, although we have so many examples.
This should override the default extension and associate .md files with the K extension.
To get the old behavior back, you can manually select Markdown in the bottom right, or disable the extension.