### PR TITLE
Support for markdown fences without extra config

### DIFF
--- a/vim/plugin/kframework.vim
+++ b/vim/plugin/kframework.vim
@@ -1,3 +1,3 @@
-au BufRead,BufNewFile *.k set filetype=kframework
-au! Syntax kframework source kframework.vim
+au BufRead,BufNewFile *.k set filetype=k
+au! Syntax k source k.vim
 syn on

--- a/vim/syntax/kframework.vim
+++ b/vim/syntax/kframework.vim
@@ -111,7 +111,7 @@ KHiLink kTodo           Todo
 
 delcommand KHiLink
   
-let b:current_syntax = "kframework"
+let b:current_syntax = "k"
 
 "EOF vim: tw=78:ft=vim:ts=8
 


### PR DESCRIPTION
Replicates #16, but not on a forked repo.

This is a cosmetic change to the actual implementation of the vim plugin, but it allows it to play nicely with the [plasticboy/vim-markdown](https://github.com/plasticboy/vim-markdown) plugin for fenced code blocks inside Markdown documents without extra configuration.

I've been using these changes for 2 years pointing to the forked version and have had no issues; I have verified that they will also not affect users of Vim plugins.